### PR TITLE
Fix dependency conflict on numpy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 matplotlib==3.5.0
-numpy==1.20.3
+numpy==1.21.0
 pandas==1.3.5


### PR DESCRIPTION
I got this conflict when running locally:

```
The conflict is caused by:
    The user requested numpy==1.20.3
    matplotlib 3.5.0 depends on numpy>=1.17
    pandas 1.3.5 depends on numpy>=1.21.0; python_version >= "3.10"

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict
```

Bumpy numpy to version 1.21.0 solved it 🙂